### PR TITLE
allow renaming YAML fields using attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@ YAML serialization library for D:YAML. Easily serialize/deserialize structs and 
 
 ## How to use
 ```D
-import yamlserialized : deserializeInto, toYAMLNode;
+import yamlserialized : deserializeInto, toYAMLNode, YamlField;
 
 struct MyStruct {
-	int intField;
-	string stringField;
+  int intField;
+  string stringField;
+  @YamlField("renamed_field")
+  string renamedField;
 }
 
 MyStruct st;
 
 st.intField = 42;
 st.stringField = "Don't panic.";
+st.renamedField = "Don't panic but in snake case."
 
 // Serialize the struct to a D:YAML Node
 auto node = st.toYAMLNode();

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,8 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dunit": "1.0.16",
+		"dyaml": "0.8.3",
+		"tinyendian": "0.2.0"
+	}
+}

--- a/source/yamlserialized/package.d
+++ b/source/yamlserialized/package.d
@@ -2,3 +2,4 @@ module yamlserialized;
 
 public import yamlserialized.deserialization;
 public import yamlserialized.serialization;
+public import yamlserialized.types;

--- a/source/yamlserialized/types.d
+++ b/source/yamlserialized/types.d
@@ -1,0 +1,7 @@
+module yamlserialized.types;
+
+/// Manually set the YAML representation name of a field with this attribute.
+struct YamlField {
+    /// name of the field that will be used in YAML
+    string name;
+}

--- a/source/yamlserialized/unittests.d
+++ b/source/yamlserialized/unittests.d
@@ -1,6 +1,28 @@
 module yamlserialized.unittests;
 
 unittest {
+    import yamlserialized : YamlField, toYAMLNode, deserializeInto;
+    import dunit.toolkit : assertEqual;
+
+    struct Test {
+        @YamlField("some_field")
+        string someField;
+    }
+
+    Test ts = Test("hello world");
+
+    auto node = ts.toYAMLNode();
+
+    assertEqual(node["some_field"], "hello world");
+
+    Test ts1;
+
+    node.deserializeInto(ts1);
+
+    assertEqual(ts1.someField, "hello world");
+}
+
+unittest {
     import std.conv : to;
     import dunit.toolkit : assertEqual;
     import dyaml : Loader;


### PR DESCRIPTION
often fields in YAML and in D code won't match, most obvious case is using snake_case in YAML but by standard D uses camelCase and switching to snake_case in D is not an ideal solution.

example usage:

```d
struct Test {
    @YamlField("some_field")
    string someField;
}

Test ts = Test("hello world");

auto node = ts.toYAMLNode();

assertEqual(node["some_field"], "hello world");

Test ts1;

node.deserializeInto(ts1);

assertEqual(ts1.someField, "hello world");
```